### PR TITLE
fix(27): make use of compose profiles so we can be selective

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ A Django application for managing and conducting sports tipping competitions.
 
 ## Services
 
-| Service | Purpose | Host port |
-|---|---|---|
-| `backend` | Django dev server | 8000 |
-| `frontend` | Vite dev server | 5173 |
-| `db` | PostgreSQL 18 | not published |
-| `migrate` | One-shot `manage.py migrate`, runs before `backend` starts | — |
-| `backend-test` | pytest | — |
-| `frontend-test` | Vitest | — |
+| Service | Purpose | Host port | Profile |
+|---|---|---|---|
+| `backend` | Django dev server | 8000 | — |
+| `frontend` | Vite dev server | 5173 | — |
+| `db` | PostgreSQL 18 | not published | — |
+| `migrate` | One-shot `manage.py migrate`, runs before `backend` starts | — | — |
+| `backend-test` | pytest | — | `test` |
+| `frontend-test` | Vitest | — | `test` |
+| `release` | python-semantic-release | — | `release` |
 
 `db` is deliberately not published to the host — everything reaches it as `db:5432` over the compose network.
+
+Services with a profile are excluded from `docker compose up`, so bringing the stack up starts the four unprofiled ones and nothing else. `docker compose run <service>` enables that service's own profile, which is why the scripts in `scripts/` reach them without naming one.
 
 ## Running
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,12 @@ services:
      - 5173:5173
     command: ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
+  # Profiled services are excluded from a plain `docker compose up`.
+  # `docker compose run <service>` enables a service's own profiles, so the
+  # scripts in scripts/ reach these without naming a profile.
+
   backend-test:
+    profiles: ["test"]
     build:
      context: ./backend
      target: test
@@ -65,6 +70,7 @@ services:
         condition: service_completed_successfully
 
   frontend-test:
+    profiles: ["test"]
     build:
       context: ./frontend
       target: test
@@ -72,6 +78,7 @@ services:
      - tipping-network
 
   release:
+    profiles: ["release"]
     build:
       context: ./backend
       target: release


### PR DESCRIPTION
Otherwise initial up runtime isn't a fun place right now. The tests run, a release service spins up.

Both making a mess of the logs and db connections.