### PR TITLE
fix(20): add in django-allauth

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 keywords = ["django-tipping", "tipping"]
 dependencies = [
     "django==6.0.7",
+    "django-allauth==65.18.0",
     "django-stubs==6.0.7",
     "factory-boy==3.3.3",
     "mypy==2.3.0",
@@ -75,6 +76,12 @@ select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
+
+# allauth ships no py.typed marker. Nothing here imports it, but the
+# django-stubs plugin walks INSTALLED_APPS and pulls in its model modules.
+[[tool.mypy.overrides]]
+module = ["allauth.*"]
+ignore_missing_imports = true
 
 [tool.django-stubs]
 django_settings_module = "tipping.settings"

--- a/backend/tipping/settings.py
+++ b/backend/tipping/settings.py
@@ -36,12 +36,17 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
+    "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
     "users",
 ]
 
 MIDDLEWARE = [
+    "allauth.account.middleware.AccountMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -70,7 +75,30 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "tipping.wsgi.application"
 
+# Authentication
 AUTH_USER_MODEL = "users.User"
+
+AUTHENTICATION_BACKENDS = (
+    "django.contrib.auth.backends.ModelBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
+)
+
+ACCOUNT_LOGIN_METHODS = {"email"}
+
+ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
+
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+
+ACCOUNT_USER_MODEL_USERNAME_FIELD = None
+
+SITE_ID = 1
+
+# Email
+EMAIL_HOST = os.getenv("EMAIL_HOST", "mail")
+
+EMAIL_PORT = os.getenv("EMAIL_PORT", 1025)
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@django-tipping.local")
 
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases

--- a/backend/tipping/urls.py
+++ b/backend/tipping/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("accounts/", include("allauth.urls")),
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -182,6 +182,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-allauth"
+version = "65.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/2d33c5bc3c0f9d7db1276a1babcaadd147e73eb416ccb1bd9523c6ac925f/django_allauth-65.18.0.tar.gz", hash = "sha256:afb82e2c545b9a5539370ad120468faaed84715e095a7b6e76972dacdc6376fe", size = 2246988, upload-time = "2026-05-29T13:01:26.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/75/5a4c2bf050e38ab16549395a7cd751ddcf3a18305bff4852cfd6c0d94998/django_allauth-65.18.0-py3-none-any.whl", hash = "sha256:e508640c83b94eaf1a9b4e9ac5332dc310dcdc83fca40d58a3f670e15bad1e84", size = 2061080, upload-time = "2026-05-29T13:01:16.532Z" },
+]
+
+[[package]]
 name = "django-stubs"
 version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -215,6 +228,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
+    { name = "django-allauth" },
     { name = "django-stubs" },
     { name = "factory-boy" },
     { name = "mypy" },
@@ -233,6 +247,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = "==6.0.7" },
+    { name = "django-allauth", specifier = "==65.18.0" },
     { name = "django-stubs", specifier = "==6.0.7" },
     { name = "factory-boy", specifier = "==3.3.3" },
     { name = "mypy", specifier = "==2.3.0" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,13 @@ services:
       timeout: 5s
       retries: 30
 
+  mail:
+    image: axllent/mailpit:v1.28
+    networks:
+     - tipping-network
+    ports:
+     - 8025:8025
+
   migrate:
     build:
       context: ./backend


### PR DESCRIPTION
Includes mailpit so the output has somewhere to go, and at least its useable for testing.

This should open up the possibility to do simple
social account auth and the like.