### PR TITLE
chore: move away from the term fixtures in modelling

### DIFF
--- a/docs/explanation/data-model.md
+++ b/docs/explanation/data-model.md
@@ -11,7 +11,7 @@ first of those working.
 
 The smallest model set that supports one flow:
 
-> A registered user joins a competition and enters a tip for each fixture in a
+> A registered user joins a competition and enters a tip for each match in a
 > round.
 
 Everything not forced by that sentence is out. This is pre-1.0 with no data to
@@ -23,15 +23,18 @@ Two, split along master data and transactional data:
 
 | App | Models | Holds |
 |---|---|---|
-| `fixtures` | `Season`, `Team`, `Fixture` | The draw. The same for everyone, and where an external feed will land. |
+| `matches` | `Season`, `Team`, `Match` | The draw. The same for everyone, and where an external feed will land. |
 | `competitions` | `Competition`, `Membership`, `Tip` | What users create and do. |
 
-`competitions` imports from `fixtures`, and nothing goes back the other way.
+`competitions` imports from `matches`, and nothing goes back the other way.
 Keeping that direction one-way means ingestion code for the feed cannot reach
 into user data, and the schedule can be reloaded without touching anyone's
 tips.
 
-## `fixtures`
+`matches` rather than `fixtures`, because Django already uses "fixtures" for
+`loaddata` seed data and pytest uses it for test fixtures.
+
+## `matches`
 
 ### `Season`
 
@@ -47,15 +50,15 @@ tips.
 | `mascot` | `CharField` | e.g. "Panthers" |
 | `abbreviation` | `CharField` | e.g. "PEN" |
 
-### `Fixture`
+### `Match`
 
 | Field | Type | Notes |
 |---|---|---|
 | `season` | `FK Season` | |
 | `round_number` | `PositiveSmallIntegerField` | An integer, not a row — see below |
-| `home_team` | `FK Team` | `related_name="home_fixtures"` |
-| `away_team` | `FK Team` | `related_name="away_fixtures"` |
-| `kickoff_time` | `DateTimeField` | Per-fixture. The round cutoff derives from it |
+| `home_team` | `FK Team` | `related_name="home_matches"` |
+| `away_team` | `FK Team` | `related_name="away_matches"` |
+| `kickoff_time` | `DateTimeField` | Per-match. The round cutoff derives from it |
 
 ## `competitions`
 
@@ -81,10 +84,10 @@ Unique on `(user, competition)`. This is the `through` model for
 | Field | Type | Notes |
 |---|---|---|
 | `membership` | `FK Membership` | Not `User` — see below |
-| `fixture` | `FK Fixture` | |
+| `match` | `FK Match` | |
 | `selected_team` | `FK Team` | |
 
-Unique on `(membership, fixture)`.
+Unique on `(membership, match)`.
 
 ## Decisions
 
@@ -94,9 +97,9 @@ in a competition the user never joined. The alternative is a `User` FK plus
 that rule enforced in application code.
 
 **`Team` is a model, and splits into `city` and `mascot`.** The flow alone
-doesn't force either — two `CharField`s on `Fixture` would do — but teams are
-the natural landing point for externally sourced data, so they need somewhere
-to live, and the split is cheap to reverse if a feed turns out to supply only a
+doesn't force either — two `CharField`s on `Match` would do — but teams are the
+natural landing point for externally sourced data, so they need somewhere to
+live, and the split is cheap to reverse if a feed turns out to supply only a
 full name.
 
 The split does not hold for every NRL side. The Dolphins have no city in their
@@ -104,11 +107,11 @@ name, and Wests Tigers' "Wests" is a club rather than a place. Either `city`
 allows blank, or it becomes a looser `location`.
 
 **`Season` exists even though nothing reads it yet.** Round 1 recurs every
-year, so fixtures need something to hang off that distinguishes them. A
+year, so matches need something to hang off that distinguishes them. A
 competition points at one season, which is also what tells the app which
-fixtures its members are tipping on.
+matches its members are tipping on.
 
-**Round is an integer on `Fixture`, not its own model.** With `Season` present,
+**Round is an integer on `Match`, not its own model.** With `Season` present,
 `(season, round_number)` identifies a round without a table. It becomes a model
 when something needs to hang off it — a stored deadline, or a round-by-round
 ladder.
@@ -127,11 +130,11 @@ Deliberately absent, each waiting for a flow that needs it:
 
 **How the round cutoff is determined.** Tipping for a round closes at the first
 game of that round, so the cutoff is the earliest `kickoff_time` among its
-fixtures. Two ways to get there:
+matches. Two ways to get there:
 
-- Compute it — an aggregate over the round's fixtures on every check. No field,
+- Compute it — an aggregate over the round's matches on every check. No field,
   and it stays correct if the draw moves.
-- Store it — a flag on `Fixture` marking the round's first game, or a stored
+- Store it — a flag on `Match` marking the round's first game, or a stored
   deadline. Cheaper to read, and needs maintaining when the draw changes.
 
 Either way a configurable cutoff, such as an offset before that time or a


### PR DESCRIPTION
Due to it being a bit of a special term in Django
and it's pretty close to @pytest.fixture as well.